### PR TITLE
Add config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Available subcommands are:
   - `stats` prints current statistics.
   - `stop`: checks if a `start` entry is in the storage `file` and calculates
     the working time, aborts if no `start` entry is found,
+  - `configure`: set some defaults for stempel and save them alongside the
+    database file. Currently available:
+    * number of months printed by the statistic command
 
 ### Options:
 
@@ -64,6 +67,7 @@ invocation of the `start` subcommand.
   - [x] Tracking: cancel started work
   - [x] Specify an offset from current time when starting or stopping
   - [ ] Add more possibilities to offset
+  - [x] Add configuration options
 
 ## License
 

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -16,11 +16,11 @@ use std::{
     io::{BufReader, Read, Write},
 };
 
+use crate::storage::WorkStorage;
+
 fn nanoseconds(_dur: &Duration) -> i32 {
     0i32
 }
-
-use crate::storage::WorkStorage;
 
 /// Alias for chrono::Duration with serde support.
 #[derive(Serialize, Deserialize)]
@@ -70,6 +70,17 @@ pub(crate) struct DurationDef {
     inner: Duration,
 }
 
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Config {
+    pub month_stats: u8,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self { month_stats: 2 }
+    }
+}
+
 /// A storage for completed and started work sets as well as started and
 /// completed breaks.
 ///
@@ -81,6 +92,8 @@ pub(crate) struct TimeBalance {
     start: Option<DateTime<Utc>>,
     breaking: Option<DateTime<Utc>>,
     breaks: Vec<DurationDef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<Config>,
     #[serde(rename = "account")]
     time_account: BTreeMap<DateTime<Utc>, DurationDef>,
 }
@@ -91,6 +104,7 @@ impl TimeBalance {
             time_account: BTreeMap::new(),
             start: None,
             breaking: None,
+            config: None,
             breaks: Vec::new(),
         }
     }
@@ -334,6 +348,7 @@ impl TryFrom<&WorkStorage> for TimeBalance {
             start,
             breaking,
             breaks,
+            config: None,
             time_account,
         })
     }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,0 +1,44 @@
+//! Tune configuration via command line.
+//!
+//! Handler for the `config` subcommand.
+
+use failure::Error;
+use std::path::Path;
+
+use crate::balance::{Config, TimeBalance};
+
+impl std::fmt::Display for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Number of months in stats: {}", self.month_stats)
+    }
+}
+
+pub fn configure<P: AsRef<Path>>(storage: P) -> Result<(), Error> {
+    let mut balance = TimeBalance::from_file(&storage, true)?;
+    let cfg = if let Some(cfg) = balance.config {
+        println!("Current configuration:");
+        println!("    {}", cfg);
+        cfg
+    } else {
+        println!("Nothing configured yet.");
+        Config::default()
+    };
+
+    println!();
+    println!("Let's change the configuration. Enter your desired value, leave blank for keeping the current value.");
+
+    let mut input = String::new();
+    println!("    Number of months to display ({}): ", cfg.month_stats);
+    std::io::stdin().read_line(&mut input)?;
+    let month_history = input.trim().parse::<u8>()?;
+    let cfg = Config {
+        month_stats: month_history,
+        // ..cfg
+    };
+
+    balance.config = Some(cfg);
+
+    balance.to_file(storage)?;
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,5 +5,6 @@
 //! handling periods and a module `stats` for printing statistics about past and
 //! current work periods.
 
+pub mod config;
 pub mod control;
 pub mod stats;

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -24,8 +24,10 @@ pub fn stats<P: AsRef<Path>>(storage: P, month: Option<crate::month::Month>) -> 
     } else {
         let m = Month::from_u32(Utc::now().month())
             .ok_or_else(|| format_err!("Failed to parse current month"))?;
-        println!("Here are your stats for the last 2 months:",);
-        stats_last_month(&balance, year, m, 2);
+        let default_cfg = crate::balance::Config::default();
+        let history = balance.config.as_ref().unwrap_or(&default_cfg).month_stats;
+        println!("Here are your stats for the last {} months:", history);
+        stats_last_month(&balance, year, m, history);
     }
 
     println!();
@@ -35,7 +37,7 @@ pub fn stats<P: AsRef<Path>>(storage: P, month: Option<crate::month::Month>) -> 
 }
 
 /// Generate month, year combination for past months and print the respective stats for them.
-fn stats_last_month(balance: &TimeBalance, year: i32, month: Month, history: i32) {
+fn stats_last_month(balance: &TimeBalance, year: i32, month: Month, history: u8) {
     let mut months: Vec<Month> = vec![month];
     let mut years: Vec<i32> = vec![year];
     (0..history).fold(month, |a, _| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,8 @@ enum Opt {
     /// Migrate json database from old to new format, creates backup file
     /// `*.bak` overwriting the original.
     Migrate(OptPath),
+    /// Configure internals of stempel.
+    Configure(OptPath),
 }
 
 /// Subcommands for break subcommand.
@@ -105,6 +107,11 @@ fn run() -> Result<(), Error> {
         Opt::Migrate(opt) => {
             debug!("Migrate");
             commands::control::migrate(opt.path.unwrap_or(default_path))?;
+        }
+        Opt::Configure(opt) => {
+            let storage = opt.path.unwrap_or(default_path);
+            debug!("Configure, stored in {:?}", storage);
+            commands::config::configure(storage)?;
         }
     }
 


### PR DESCRIPTION
Allow number of months printed by `stempel stats` to be configured with `stempel configure`.